### PR TITLE
Allowing passing of terminal options to simpl#load

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The first loads the current buffer:
 call simpl#load()
 ```
 
+See the docs for more on this function's arguments.
+
 The second prompts for a buffer to load:
 
 ```vim

--- a/autoload/simpl.vim
+++ b/autoload/simpl.vim
@@ -2,7 +2,7 @@ function simpl#repl(...) abort
   let l:interpreter = get(b:, 'interpreter', &shell)
   let l:command = 'term'
   if a:0
-    for l:opt in a:000
+    for l:opt in a:000[0]
       let l:command .= printf(' %s', opt)
     endfor
   endif
@@ -48,10 +48,10 @@ function s:should_do_load() abort
   return has_key(s:simpl(), &filetype)
 endfunction
 
-function s:do_load(expr) abort
+function s:do_load(expr, ...) abort
   let l:terms = term_list()
   if empty(term_list())
-    call simpl#repl('++close')
+    call call(function("simpl#repl"), a:000)
     let l:terms = term_list()
   endif
 
@@ -61,20 +61,20 @@ function s:do_load(expr) abort
   exec l:win 'wincmd w'
 endfunction
 
-function simpl#load() abort
+function simpl#load(...) abort
   if s:should_do_load()
     let l:file = expand('%')
     let l:code = s:simpl()[&filetype]['buildloadexpr'](l:file)
-    call s:do_load(l:code)
+    call s:do_load(l:code, a:000)
   endif
 endfunction
 
-function simpl#prompt_and_load() abort
+function simpl#prompt_and_load(term_opts) abort
   if s:should_do_load()
     let l:text = s:simpl()[&filetype]['getprompttext']()
     let l:file = input(l:text, expand('%'), 'file')
     let l:code = s:simpl()[&filetype]['buildloadexpr'](l:file)
-    call s:do_load(l:code)
+    call s:do_load(l:code, a:term_opts)
   endif
 endfunction
 

--- a/autoload/simpl.vim
+++ b/autoload/simpl.vim
@@ -65,7 +65,7 @@ function simpl#load(...) abort
   if s:should_do_load()
     let l:file = expand('%')
     let l:code = s:simpl()[&filetype]['buildloadexpr'](l:file)
-		call call(function('s:do_load'), [l:code] + a:000)
+    call call(function('s:do_load'), [l:code] + a:000)
   endif
 endfunction
 
@@ -74,7 +74,7 @@ function simpl#prompt_and_load(...) abort
     let l:text = s:simpl()[&filetype]['getprompttext']()
     let l:file = input(l:text, expand('%'), 'file')
     let l:code = s:simpl()[&filetype]['buildloadexpr'](l:file)
-		call call(function('s:do_load'), [l:code] + a:000)
+    call call(function('s:do_load'), [l:code] + a:000)
   endif
 endfunction
 

--- a/autoload/simpl.vim
+++ b/autoload/simpl.vim
@@ -2,7 +2,7 @@ function simpl#repl(...) abort
   let l:interpreter = get(b:, 'interpreter', &shell)
   let l:command = 'term'
   if a:0
-    for l:opt in a:000[0]
+    for l:opt in a:000
       let l:command .= printf(' %s', opt)
     endfor
   endif
@@ -65,7 +65,7 @@ function simpl#load(...) abort
   if s:should_do_load()
     let l:file = expand('%')
     let l:code = s:simpl()[&filetype]['buildloadexpr'](l:file)
-    call s:do_load(l:code, a:000)
+		call call(function('s:do_load'), [l:code] + a:000)
   endif
 endfunction
 
@@ -74,7 +74,7 @@ function simpl#prompt_and_load(...) abort
     let l:text = s:simpl()[&filetype]['getprompttext']()
     let l:file = input(l:text, expand('%'), 'file')
     let l:code = s:simpl()[&filetype]['buildloadexpr'](l:file)
-    call s:do_load(l:code, a:000)
+		call call(function('s:do_load'), [l:code] + a:000)
   endif
 endfunction
 

--- a/autoload/simpl.vim
+++ b/autoload/simpl.vim
@@ -69,12 +69,12 @@ function simpl#load(...) abort
   endif
 endfunction
 
-function simpl#prompt_and_load(term_opts) abort
+function simpl#prompt_and_load(...) abort
   if s:should_do_load()
     let l:text = s:simpl()[&filetype]['getprompttext']()
     let l:file = input(l:text, expand('%'), 'file')
     let l:code = s:simpl()[&filetype]['buildloadexpr'](l:file)
-    call s:do_load(l:code, a:term_opts)
+    call s:do_load(l:code, a:000)
   endif
 endfunction
 

--- a/doc/simpl.txt
+++ b/doc/simpl.txt
@@ -65,18 +65,24 @@ simpl#popup_shell([{opts}])
                                                                   *simpl#load*
 simpl#load([{opts}])
                 Loads a file or module into the REPL/interpreter. Opens one if
-                none exists. If none exists, the optional parameter {opts} is
-		passed to the newly created terminal buffer; {opts} should be
-		terminal options, for instance '++rows=10'.
+                none exists. If none exists, the optional variadic parameters 
+		{opts} are passed to the newly created terminal buffer; {opts}
+		should be terminal options, separated by a comma.
+		For instance simpl#load('++rows=10', '++close').
 		simpl#load passes the current file as arguments to the
                 filetype's callback. See also |simpl_mods|.
 
 
                                                        *simpl#prompt_and_load*
-simpl#prompt_and_load()
+simpl#prompt_and_load([{opts}])
                 Loads a file or module into the REPL/interpreter. Opens one
-                if none exists. Prompts for a filename based on the
-                filetype's callback. See also |simpl_mods|.
+                if none exists. 
+		Prompts for a filename based on the filetype's callback. 
+		See also |simpl_mods|.
+		The optional variadic parameters {opts} are passed to the 
+		terminal buffer if no terminal buffer already exists.
+		{opts} should be terminal options, separated by a comma.
+		For instance simpl#prompt_and_load('++rows=10', '++close').
 
                                                                   *simpl_mods*
 This global-local variable influences how new windows are opened. It defaults

--- a/doc/simpl.txt
+++ b/doc/simpl.txt
@@ -63,9 +63,12 @@ simpl#popup_shell([{opts}])
                 still be running if you do. See also |simpl_mods|.
 
                                                                   *simpl#load*
-simpl#load()
+simpl#load([{opts}])
                 Loads a file or module into the REPL/interpreter. Opens one if
-                none exists. Passes the current file as arguments to the
+                none exists. If none exists, the optional parameter {opts} is
+		passed to the newly created terminal buffer; {opts} should be
+		terminal options, for instance '++rows=10'.
+		simpl#load passes the current file as arguments to the
                 filetype's callback. See also |simpl_mods|.
 
 

--- a/doc/simpl.txt
+++ b/doc/simpl.txt
@@ -65,24 +65,24 @@ simpl#popup_shell([{opts}])
                                                                   *simpl#load*
 simpl#load([{opts}])
                 Loads a file or module into the REPL/interpreter. Opens one if
-                none exists. If none exists, the optional variadic parameters 
-		{opts} are passed to the newly created terminal buffer; {opts}
-		should be terminal options, separated by a comma.
-		For instance simpl#load('++rows=10', '++close').
-		simpl#load passes the current file as arguments to the
+                none exists. The optional parameters {opts} are passed to the
+                newly created terminal buffer; {opts} should be |:terminal|
+                options separated by a comma (see |:term++close|). For
+                example: >
+    :call simpl#load('++rows=10', '++close')
+<               simpl#load passes the current file as arguments to the
                 filetype's callback. See also |simpl_mods|.
 
 
                                                        *simpl#prompt_and_load*
 simpl#prompt_and_load([{opts}])
                 Loads a file or module into the REPL/interpreter. Opens one
-                if none exists. 
-		Prompts for a filename based on the filetype's callback. 
-		See also |simpl_mods|.
-		The optional variadic parameters {opts} are passed to the 
-		terminal buffer if no terminal buffer already exists.
-		{opts} should be terminal options, separated by a comma.
-		For instance simpl#prompt_and_load('++rows=10', '++close').
+                if none exists. Prompts for a filename based on the filetype's
+                callback. See also |simpl_mods|.
+
+                The optional variadic parameters {opts} are passed to the
+                terminal buffer if no terminal buffer already exists. See
+                |simpl#load| for details.
 
                                                                   *simpl_mods*
 This global-local variable influences how new windows are opened. It defaults


### PR DESCRIPTION
The `simpl#load` function is handy, it creates a terminal buffer it none exists and executes the command to start a REPL.

It however doesn't give me the possibility to pass in specific terminal buffer options.

In my use case, I want to be able to specify the height or width of the terminal buffer using '++rows=10`.

This requests adds an optional parameter to simpl#load called `term_opts`.

For your consideration,
Cheers,