### PR TITLE
Feature : adding simpl#popup_load

### DIFF
--- a/autoload/simpl.vim
+++ b/autoload/simpl.vim
@@ -26,7 +26,7 @@ function simpl#shell(...) abort
 endfunction
 
 function s:popup(win_id, ...) abort
-	let l:options = !empty(a:000) ? a:000[0] : #{}
+  let l:options = !empty(a:000) ? a:000[0] : #{}
   const buf = win_id2win(a:win_id)->winbufnr()
   call win_gotoid(a:win_id)
   hide
@@ -34,7 +34,7 @@ function s:popup(win_id, ...) abort
 endfunction
 
 function s:popup_options() abort
-	return get(b:, "simpl_popup_options", #{minheight: &lines-10, minwidth: &columns-10, border:[], padding: []})
+  return get(b:, "simpl_popup_options", #{minheight: &lines-10, minwidth: &columns-10, border:[], padding: []})
 endfunction
 
 function simpl#popup_repl(...) abort
@@ -43,15 +43,15 @@ endfunction
 
 function simpl#popup_load(...) abort
   let l:file = expand('%')
-	let l:code = s:simpl()[&filetype]['buildloadexpr'](l:file)
-	let l:term_win_id = call("simpl#repl", ['++close'] + a:000)
+  let l:code = s:simpl()[&filetype]['buildloadexpr'](l:file)
+  let l:term_win_id = call("simpl#repl", ['++close'] + a:000)
   call term_sendkeys(win_id2win(l:term_win_id)->winbufnr(), l:code)
   let l:popup = s:popup(l:term_win_id, s:popup_options())
-	" The pop-up does not seem to delete closed terminal buffers.
-	" This in turn would break calls to simpl#load();
-	" it would try to load code in an inactive terminal buffer.
-	if &buftype == 'terminal' | setlocal bufhidden=wipe | endif
-	return l:popup
+  " The pop-up does not seem to delete closed terminal buffers.
+  " This in turn would break calls to simpl#load();
+  " it would try to load code in an inactive terminal buffer.
+  if &buftype == 'terminal' | setlocal bufhidden=wipe | endif
+  return l:popup
 endfunction
 
 function simpl#popup_shell(...) abort

--- a/autoload/simpl.vim
+++ b/autoload/simpl.vim
@@ -25,15 +25,33 @@ function simpl#shell(...) abort
   return id
 endfunction
 
-function s:popup(id) abort
-  const buf = win_id2win(a:id)->winbufnr()
-  call win_gotoid(a:id)
+function s:popup(win_id, ...) abort
+	let l:options = !empty(a:000) ? a:000[0] : #{}
+  const buf = win_id2win(a:win_id)->winbufnr()
+  call win_gotoid(a:win_id)
   hide
-  return popup_create(buf, #{minheight: &lines-10, minwidth: &columns-10, border:[], padding: []})
+  return popup_create(buf, l:options)
+endfunction
+
+function s:popup_options() abort
+	return get(b:, "simpl_popup_options", #{minheight: &lines-10, minwidth: &columns-10, border:[], padding: []})
 endfunction
 
 function simpl#popup_repl(...) abort
   return s:popup(call('simpl#repl', ['++close'] + a:000))
+endfunction
+
+function simpl#popup_load(...) abort
+  let l:file = expand('%')
+	let l:code = s:simpl()[&filetype]['buildloadexpr'](l:file)
+	let l:term_win_id = call("simpl#repl", ['++close'] + a:000)
+  call term_sendkeys(win_id2win(l:term_win_id)->winbufnr(), l:code)
+  let l:popup = s:popup(l:term_win_id, s:popup_options())
+	" The pop-up does not seem to delete closed terminal buffers.
+	" This in turn would break calls to simpl#load();
+	" it would try to load code in an inactive terminal buffer.
+	if &buftype == 'terminal' | setlocal bufhidden=wipe | endif
+	return l:popup
 endfunction
 
 function simpl#popup_shell(...) abort

--- a/doc/simpl.txt
+++ b/doc/simpl.txt
@@ -55,6 +55,15 @@ simpl#popup_repl([{opts}])
                 |popup_clear()| in a pinch, but note that the repl may still
                 be running if you do. See also |simpl_mods|.
 
+                                                            *simpl#popup_load*
+simpl#popup_load([{opts}])
+                Like |simpl#load| with `++close`, but uses a popup. Opposite
+		of *simpl#repl* , this loads the file contents into the pop-up
+		REPL.
+		You must close the popup (e.g., by quitting the repl) to continue,
+		using a keyboard shortcut such as CTRL+C or CTRL+D often works.
+                See also |simpl_mods|.
+
                                                            *simpl#popup_shell*
 simpl#popup_shell([{opts}])
                 Like |simpl#shell| with `++close`, but uses a popup. You must
@@ -142,6 +151,13 @@ simpl#register(filetype, BuildLoadExpr, GetPromptText)
 If truthy, simpl will not register its default filetype information. Note
 however that, when calling |simpl#register| with the same filetype, the
 last call will override all others.
+
+                                                         *b:simpl_popup_options*
+Dictionary, see *popup_create-arguments* {options}. If you wish to override
+the default popup arguments, you may `let b:simpl_popup_conf`  
+The default settings are:  
+`#{minheight: &lines-10, minwidth: &columns-10, border:[], padding: []}`
+
 
 ==============================================================================
 LICENSE                                                        *simpl-license*


### PR DESCRIPTION
I've added a function called `simpl#popup_load` in my fork of vim-simpl.  
I believe it may interest users of vim-simpl.

`simpl#popup_load` It sends the content of the current buffer into a new pop-up terminal buffer, then wipes the closed terminal buffer from the buffer list.

*My use case:* 
I have limited screen space and enjoy running the repl in a pop-up.  
I use it more-so to execute code, observe the result, close the pop-up and continue, this frees space on my screen.  
This is very useful in the context of executing tests, and doing TDD.
I also can have a fixed terminal buffer open at the bottom of my Vim viewport using simpl#load, and simultaneously execute `simpl#popup_load` without both having to interact.


For your consideration,